### PR TITLE
IBX-8118: Implemented RemoveLegacyClassAliasRector rule

### DIFF
--- a/src/lib/Rule/Internal/RemoveLegacyClassAliasRector.php
+++ b/src/lib/Rule/Internal/RemoveLegacyClassAliasRector.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Rule\Internal;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @internal This rule is internal, for Ibexa 1st party packages
+ */
+final class RemoveLegacyClassAliasRector extends AbstractRector
+{
+    /** @var array<string> */
+    private const array FQCN_PREFIXES = ['eZ\\', 'EzSystems\\', 'Ibexa\\'];
+
+    /**
+     * @throws \Exception
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove legacy eZ Systems & Ibexa class_alias calls', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+$x = 'something';
+class_alias(Foo::class, 'eZ\Foo');
+class_alias(Foo::class, 'Other\ThirdParty\Foo');
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+$x = 'something';
+class_alias(Foo::class, 'Other\ThirdParty\Foo');
+CODE_SAMPLE
+            ,
+            ['var_dump']
+        )]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Expression::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Expression $node
+     */
+    public function refactor(Node $node): ?int
+    {
+        $expr = $node->expr;
+        if (!$expr instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        $args = $expr->getArgs();
+        if (!$this->isName($expr->name, 'class_alias') || !$this->isLegacyClassAlias($args)) {
+            return null;
+        }
+
+        return NodeTraverser::REMOVE_NODE;
+    }
+
+    /**
+     * @param \PhpParser\Node\Arg[] $args
+     */
+    private function isLegacyClassAlias(array $args): bool
+    {
+        if (!isset($args[1]) || !$args[1]->value instanceof Node\Scalar\String_) {
+            return false;
+        }
+
+        $value = $args[1]->value->value;
+
+        foreach (self::FQCN_PREFIXES as $prefix) {
+            if (str_starts_with($value, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/another_class.php.inc
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/another_class.php.inc
@@ -1,0 +1,27 @@
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyAnotherLegacyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+class_alias(MyAnotherLegacyClass::class, 'eZ\Some\Namespace\MyAnotherLegacyClass');
+
+?>
+-----
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyAnotherLegacyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/bc_ibexa_class.php.inc
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/bc_ibexa_class.php.inc
@@ -1,0 +1,27 @@
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyIbexaClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+class_alias(MyIbexaClass::class, 'Ibexa\Platform\MyAnotherLegacyClass');
+
+?>
+-----
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyIbexaClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/some_class.php.inc
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/some_class.php.inc
@@ -1,0 +1,27 @@
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyLegacyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+class_alias(MyLegacyClass::class, 'EzSystems\Some\Namespace\MyLegacyClass');
+
+?>
+-----
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyLegacyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/third_party_class.php.inc
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/third_party_class.php.inc
@@ -1,0 +1,31 @@
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class ThirdPartyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+// this is not ours, should remain
+class_alias(ThirdPartyClass::class, 'ThirdPartyVendor\Accidental\Ibexa\Collsion');
+
+?>
+-----
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class ThirdPartyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+// this is not ours, should remain
+class_alias(ThirdPartyClass::class, 'ThirdPartyVendor\Accidental\Ibexa\Collsion');
+
+?>

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/RemoveLegacyClassAliasRectorTest.php
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/RemoveLegacyClassAliasRectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @covers \Ibexa\Rector\Rule\Internal\RemoveLegacyClassAliasRector
+ */
+final class RemoveLegacyClassAliasRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @throws \Rector\Exception\ShouldNotHappenException
+     */
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/config/configured_rule.php
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Rector\Rule\Internal\RemoveLegacyClassAliasRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveLegacyClassAliasRector::class);
+};


### PR DESCRIPTION
| :ticket: Issue | IBX-8118 |
|----------------|-----------|

#### Description:

This PR defines the first rule, to remove our BC layer class_alias statements from the codebase.

##### Usage

Create `./rector.php`:
```php
<?php

/**
 * @copyright Copyright (C) Ibexa AS. All rights reserved.
 * @license For full copyright and license information view LICENSE file distributed with this source code.
 */
declare(strict_types=1);

use Ibexa\Rector\Rule\Internal\RemoveLegacyClassAliasRector;
use Rector\Config\RectorConfig;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths(
        [
            __DIR__ . '/src', // see if it matches your project structure
            __DIR__ . '/tests',
        ]
    );

    $rectorConfig->rule(RemoveLegacyClassAliasRector::class);
};
```

#### For QA:

Optionally, check if the rector rule works as expected.

#### Documentation:

No doc needed, this is an internal rule.

