### PR TITLE
IBX-8315: Fixed handling missing usages of class_alias

### DIFF
--- a/src/lib/Rule/Internal/RemoveLegacyClassAliasRector.php
+++ b/src/lib/Rule/Internal/RemoveLegacyClassAliasRector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveLegacyClassAliasRector extends AbstractRector
 {
     /** @var array<string> */
-    private const array FQCN_PREFIXES = ['eZ\\', 'EzSystems\\', 'Ibexa\\'];
+    private const array FQCN_PREFIXES = ['eZ\\', 'EzSystems\\', 'Ibexa\\', 'spec\\EzSystems'];
 
     /**
      * @throws \Exception

--- a/src/lib/Rule/Internal/RemoveLegacyClassAliasRector.php
+++ b/src/lib/Rule/Internal/RemoveLegacyClassAliasRector.php
@@ -74,18 +74,28 @@ CODE_SAMPLE
      */
     private function isLegacyClassAlias(array $args): bool
     {
-        if (!isset($args[1]) || !$args[1]->value instanceof Node\Scalar\String_) {
+        if (!isset($args[1]) || null === ($classFQCN = $this->getFQCNFromArgValue($args[1]->value))) {
             return false;
         }
 
-        $value = $args[1]->value->value;
-
         foreach (self::FQCN_PREFIXES as $prefix) {
-            if (str_starts_with($value, $prefix)) {
+            if (str_starts_with($classFQCN, $prefix)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function getFQCNFromArgValue(Node\Expr $value): ?string
+    {
+        if ($value instanceof Node\Scalar\String_) {
+            return $value->value;
+        }
+        if ($value instanceof Node\Expr\ClassConstFetch) {
+            return $this->getName($value);
+        }
+
+        return null;
     }
 }

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/as_fqcn_class_const_multilined.php.inc
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/as_fqcn_class_const_multilined.php.inc
@@ -1,0 +1,30 @@
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyYetAnotherLegacyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+class_alias(
+        MyYetAnotherLegacyClass::class,
+        \EzSystems\Some\Namespace\MyYetAnotherLegacyClass::class
+);
+
+?>
+-----
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MyYetAnotherLegacyClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>

--- a/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/spec_namespace.php.inc
+++ b/tests/lib/Rule/Internal/RemoveLegacyClassAliasRector/Fixture/spec_namespace.php.inc
@@ -1,0 +1,30 @@
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MySpecTestCase
+{
+    public function foo(): void
+    {
+    }
+}
+
+class_alias(
+    MySpecTestCase::class,
+    'spec\EzSystems\Some\Namespace\MySpecTestCase'
+);
+
+?>
+-----
+<?php /** @noinspection ALL */
+
+namespace Ibexa\Rector\Tests\Rule\Internal\RemoveLegacyClassAliasRector\Fixture;
+
+class MySpecTestCase
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
| :ticket: Issue | IBX-8315 |
|----------------|-----------|


#### Description:

This PR adds handling of:
1. `class_alias` with 2nd argument given as `::class` constant fetch
2. `class_alias` called with `spec\EzSystems` namespaces as 2nd argument