### PR TITLE
IBX-8531: Added rules for ibexa/system-info deprecations

### DIFF
--- a/src/contracts/Sets/ibexa-50.php
+++ b/src/contracts/Sets/ibexa-50.php
@@ -9,7 +9,38 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Rector\Sets;
 
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Renaming\ValueObject\RenameProperty;
 
 return static function (RectorConfig $rectorConfig): void {
-    // list of rector rules to upgrade Ibexa projects to Ibexa DXP 5.0
+    // List of rector rules to upgrade Ibexa projects to Ibexa DXP 5.0
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassConstFetch(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector',
+                'CONTENT_PACKAGES',
+                'HEADLESS_PACKAGES'
+            ),
+            new RenameClassConstFetch(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector',
+                'ENTERPRISE_PACKAGES',
+                'HEADLESS_PACKAGES'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo',
+                'stability',
+                'lowestStability',
+            ),
+        ]
+    );
 };


### PR DESCRIPTION
| :ticket: Issue | IBX-8531 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Provided rector rules for the following deprecated symbols:

- `\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector::CONTENT_PACKAGES`
- `\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector::ENTERPRISE_PACKAGES`
- `\Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo::$stability` 

Both classes are considered as internal and and are unlikely to be used outside the  `ibexa/system-info` package. 
 
See also https://github.com/ibexa/system-info/pull/55

#### For QA:

N/A

#### Documentation:

Update upgrade guide. 

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
