### PR TITLE
IBX-8394: Created Rector to rename RepositoryConfigurationProvider usages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ This guide is meant for adding rules to this package. For custom project rules, 
   - `./src/contracts/Sets/ibexa-50.php` is a ruleset which contains all the rules for Ibexa DXP 5.0 upgrade, new rules 
     should be added there.
 * `./src/lib/Rule` - directory to implement specific rules, following [Rector's official doc](https://getrector.com/documentation/custom-rule).
-  - `./src/lib/Rule/Ibexa50/` - directory to implement Ibexa 5.0 upgrade specific rules
-* `./tests/lib/Rule` - directory to implement a specific rule tests, should contain subdirectory named `<RuleName>/`
+  - `./src/lib/Rule/Ibexa50/` - directory to implement Ibexa 5.0 upgrade specific rules.
+* `./tests/lib/Rule` - directory to implement a specific rule tests, should contain subdirectory named `<RuleName>/`.
+* `./tests/lib/Sets/Ibexa50/` - directory to implement specific use cases for Ibexa 5.0 set configuration, if not covered by Rector tests.
 
 ## Creating custom rules
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,26 @@ composer require --dev ibexa/rector:~5.0.x-dev
 ## Usage
 
 1. Create `./rector.php` file in your project, with the following contents, adjusted to your project structure:
-    ```php
-    use Rector\Config\RectorConfig;
+   ```php
+   declare(strict_types=1);
 
-    return static function (RectorConfig $rectorConfig): void {
-        $rectorConfig->paths([
-            __DIR__ . '/src', // see if it matches your project structure  
-            __DIR__ . '/tests',
-        ]);
-    
-        // define sets of rules
-        $rectorConfig->sets([
-            __DIR__ . '/vendor/ibexa/rector/src/contracts/Sets/ibexa-50.php' // rule set for upgrading to Ibexa DXP 5.0
-        ]);
-    };
-    ```
+   use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+   use Rector\Config\RectorConfig;
+
+   return RectorConfig::configure()
+                      ->withPaths(
+                          [
+                              __DIR__ . '/src', // see if it matches your project structure
+                              __DIR__ . '/tests'
+                          ]
+                      )
+                      ->withSets(
+                          [
+                              IbexaSetList::IBEXA_50->value // rule set for upgrading to Ibexa DXP 5.0
+                          ]
+                      )
+   ;
+   ```
 2. Execute Rector
     ```
     php ./bin/rector process <directory>

--- a/src/contracts/Sets/IbexaSetList.php
+++ b/src/contracts/Sets/IbexaSetList.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Rector\Sets;
+
+enum IbexaSetList: string
+{
+    case IBEXA_50 = __DIR__ . '/ibexa-50.php';
+}

--- a/src/contracts/Sets/ibexa-50.php
+++ b/src/contracts/Sets/ibexa-50.php
@@ -10,12 +10,19 @@ namespace Ibexa\Contracts\Rector\Sets;
 
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Renaming\ValueObject\RenameProperty;
 
 return static function (RectorConfig $rectorConfig): void {
     // List of rector rules to upgrade Ibexa projects to Ibexa DXP 5.0
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Bundle\\Core\\ApiLoader\\RepositoryConfigurationProvider' => 'Ibexa\\Contracts\\Core\\Container\\ApiLoader\\RepositoryConfigurationProviderInterface',
+        ]
+    );
 
     $rectorConfig->ruleWithConfiguration(
         RenameClassConstFetchRector::class,

--- a/tests/lib/Sets/Ibexa50/Fixture/some_class.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/some_class.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+
+class FooBar {
+    public function foo(): RepositoryConfigurationProvider
+    {
+        return $this->bar(RepositoryConfigurationProvider::class);
+    }
+
+    public function bar(string $class): RepositoryConfigurationProvider
+    {
+        return new $class();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+
+class FooBar {
+    public function foo(): \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
+    {
+        return $this->bar(\Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface::class);
+    }
+
+    public function bar(string $class): \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
+    {
+        return new $class();
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa50/Ibexa50Test.php
+++ b/tests/lib/Sets/Ibexa50/Ibexa50Test.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Ibexa50Test extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/lib/Sets/Ibexa50/config/configured_rule.php
+++ b/tests/lib/Sets/Ibexa50/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([IbexaSetList::IBEXA_50->value]);
+};


### PR DESCRIPTION
| :ticket: Issue | IBX-8394 |
|----------------|-----------|

#### Description:

Added to Ibexa 5.0 set list a rule which renames usages of deprecated `\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider` with
`\Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface`

Added also test coverage for the Ibexa 5.0 set - can be in the future expaned with coverage for pre-existing and new configuration.

DX: Defined `\Ibexa\Contracts\Rector\Sets\IbexaSetList` set list, so the Developer's `rector.php` config could be as follows:

```php
   
declare(strict_types=1);

use Ibexa\Contracts\Rector\Sets\IbexaSetList;
use Rector\Config\RectorConfig;

return RectorConfig::configure()
                   ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
                   ->withSets([IbexaSetList::IBEXA_50->value])
;
```
instead of hardcoded path from `./vendor/...`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:

Changed example configuration.

