### PR TITLE
[Tests] Configured importing FQCNs for Ibexa 5.0 rector set tests

### DIFF
--- a/tests/lib/Sets/Ibexa50/Fixture/fieldtype_page_const.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/fieldtype_page_const.php.inc
@@ -21,14 +21,15 @@ class Foo {
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
 
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension;
 use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;
 
 class Foo {
     public function foo(): array
     {
         return [
-            \Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension::EXTENSION_NAME,
-            \Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension::EXTENSION_NAME
+            IbexaFieldTypePageExtension::EXTENSION_NAME,
+            IbexaFieldTypePageExtension::EXTENSION_NAME
         ];
     }
 

--- a/tests/lib/Sets/Ibexa50/Fixture/rest_rename.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/rest_rename.php.inc
@@ -2,23 +2,26 @@
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Rest\Output\Generator;
+use Ibexa\Rest\Output\FieldTypeSerializer;
 
 class Foo {
     public function mediaTypeGenerator(): void
     {
-        $generator = new \Ibexa\Contracts\Rest\Output\Generator();
+        $generator = new Generator();
 
         return $generator->generateMediaType('name', 'type');
     }
 
     public function fieldTypeSerializer(): void
     {
-        $serializer = new \Ibexa\Rest\Output\FieldTypeSerializer();
+        $serializer = new FieldTypeSerializer();
 
-        $generator = new \Ibexa\Contracts\Rest\Output\Generator();
-        $contentType = new \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType();
-        $field = new \Ibexa\Contracts\Core\Repository\Values\Content\Field();
+        $generator = new Generator();
+        $contentType = new ContentType();
+        $field = new Field();
 
         return $serializer->serializeFieldValue($generator, $contentType, $field);
     }
@@ -30,23 +33,26 @@ class Foo {
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Rest\Output\Generator;
+use Ibexa\Rest\Output\FieldTypeSerializer;
 
 class Foo {
     public function mediaTypeGenerator(): void
     {
-        $generator = new \Ibexa\Contracts\Rest\Output\Generator();
+        $generator = new Generator();
 
         return $generator->generateMediaTypeWithVendor('name', 'type');
     }
 
     public function fieldTypeSerializer(): void
     {
-        $serializer = new \Ibexa\Rest\Output\FieldTypeSerializer();
+        $serializer = new FieldTypeSerializer();
 
-        $generator = new \Ibexa\Contracts\Rest\Output\Generator();
-        $contentType = new \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType();
-        $field = new \Ibexa\Contracts\Core\Repository\Values\Content\Field();
+        $generator = new Generator();
+        $contentType = new ContentType();
+        $field = new Field();
 
         return $serializer->serializeContentFieldValue($generator, $field);
     }

--- a/tests/lib/Sets/Ibexa50/Fixture/some_class.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/some_class.php.inc
@@ -22,15 +22,15 @@ class FooBar {
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 
 class FooBar {
-    public function foo(): \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
+    public function foo(): RepositoryConfigurationProviderInterface
     {
-        return $this->bar(\Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface::class);
+        return $this->bar(RepositoryConfigurationProviderInterface::class);
     }
 
-    public function bar(string $class): \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface
+    public function bar(string $class): RepositoryConfigurationProviderInterface
     {
         return new $class();
     }

--- a/tests/lib/Sets/Ibexa50/config/configured_rule.php
+++ b/tests/lib/Sets/Ibexa50/config/configured_rule.php
@@ -11,4 +11,5 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([IbexaSetList::IBEXA_50->value]);
+    $rectorConfig->importNames();
 };


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

Initially it looked like there was an easy way to make Rector refactor classes using imports instead of FQCNs.
```php
$rectorConfig->importNames();
```
However I cannot add this to the production config, as it turns out it refactors every FQCN, not just the ones affected by the changes, as I initially thought.

At least we can make the tests more readable.