### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
     "require": {
         "php": ">=8.3",
         "rector/rector": "^1.0",
-        "symfony/config": "^5.4",
-        "symfony/console": "^5.4",
-        "symfony/dependency-injection": "^5.4",
-        "symfony/event-dispatcher": "^5.4",
-        "symfony/http-foundation": "^5.4",
-        "symfony/http-kernel": "^5.4",
-        "symfony/yaml": "^5.4"
+        "symfony/config": "^6.4",
+        "symfony/console": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/event-dispatcher": "^6.4",
+        "symfony/http-foundation": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/yaml": "^6.4"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",


### PR DESCRIPTION
| :ticket: Issue | IBX-8470 |
|----------------|-----------|

#### Description:

This PR bumps Symfony to v6 with codebase upgrades.

Key changes:

- [x] Bumped PHP version to 8.3

#### QA:

N/A

#### Documentation:

N/A


