### PR TITLE
IBX-9627: Replaced Symfony code quality set with specific rules

### DIFF
--- a/src/contracts/Factory/IbexaRectorConfigFactory.php
+++ b/src/contracts/Factory/IbexaRectorConfigFactory.php
@@ -11,6 +11,9 @@ namespace Ibexa\Contracts\Rector\Factory;
 use Ibexa\Contracts\Rector\Sets\IbexaSetList;
 use Rector\Config\RectorConfig;
 use Rector\Configuration\RectorConfigBuilder;
+use Rector\Symfony\CodeQuality\Rector\BinaryOp\ResponseStatusCodeRector;
+use Rector\Symfony\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector;
+use Rector\Symfony\CodeQuality\Rector\MethodCall\LiteralGetToRequestClassConstantRector;
 use Rector\Symfony\Set\SymfonySetList;
 
 final readonly class IbexaRectorConfigFactory implements IbexaRectorConfigFactoryInterface
@@ -30,8 +33,9 @@ final readonly class IbexaRectorConfigFactory implements IbexaRectorConfigFactor
            ->withPaths($this->pathsToProcess)
            ->withRules(
                [
-                    EventListenerToEventSubscriberRector::class,
-                    LiteralGetToRequestClassConstantRector::class,
+                   EventListenerToEventSubscriberRector::class,
+                   LiteralGetToRequestClassConstantRector::class,
+                   ResponseStatusCodeRector::class,
                ]
            )
            ->withSets(

--- a/src/contracts/Factory/IbexaRectorConfigFactory.php
+++ b/src/contracts/Factory/IbexaRectorConfigFactory.php
@@ -28,6 +28,12 @@ final readonly class IbexaRectorConfigFactory implements IbexaRectorConfigFactor
     {
         return RectorConfig::configure()
            ->withPaths($this->pathsToProcess)
+           ->withRules(
+               [
+                    EventListenerToEventSubscriberRector::class,
+                    LiteralGetToRequestClassConstantRector::class,
+               ]
+           )
            ->withSets(
                array_merge(
                    [
@@ -39,7 +45,6 @@ final readonly class IbexaRectorConfigFactory implements IbexaRectorConfigFactor
                        SymfonySetList::SYMFONY_52_VALIDATOR_ATTRIBUTES,
                        SymfonySetList::SYMFONY_53,
                        SymfonySetList::SYMFONY_54,
-                       SymfonySetList::SYMFONY_CODE_QUALITY,
                        SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
                        SymfonySetList::SYMFONY_60,
                        SymfonySetList::SYMFONY_61,

--- a/tests/contracts/IbexaRectorConfigFactoryTest.php
+++ b/tests/contracts/IbexaRectorConfigFactoryTest.php
@@ -16,6 +16,9 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Symfony\Set\SymfonySetList;
 
+/**
+ * @covers \Ibexa\Contracts\Rector\Factory\IbexaRectorConfigFactory
+ */
 final class IbexaRectorConfigFactoryTest extends TestCase
 {
     /**
@@ -46,7 +49,6 @@ final class IbexaRectorConfigFactoryTest extends TestCase
             SymfonySetList::SYMFONY_52,
             SymfonySetList::SYMFONY_53,
             SymfonySetList::SYMFONY_54,
-            SymfonySetList::SYMFONY_CODE_QUALITY,
             SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
             SymfonySetList::SYMFONY_60,
             SymfonySetList::SYMFONY_61,


### PR DESCRIPTION
| :ticket: Issue | IBX-9627 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/rector/pull/24


#### Description:

This is a follow-up to #24. Code quality Symfony Set List proved to be too volatile. For example, it removes `Action` suffix from controllers while not updating controller configuration YAMLs, which makes it not suitable for automated CI jobs.

Instead, I've chosen 3 Rectors from that set list, which provide a value:
* `EventListenerToEventSubscriberRector`
* `LiteralGetToRequestClassConstantRector` // converts `'GET'` literals to use a const from SF
* `ResponseStatusCodeRector` // converts HTTP status codes to use a const from SF
