### PR TITLE
Backported Rector Set for Ibexa 4.6

### DIFF
--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -135,4 +135,16 @@ return static function (RectorConfig $rectorConfig): void {
             'Ibexa\\Contracts\\Shipping\\Iterator\\BatchIteratorAdapter\\RegionFetchAdapter' => 'Ibexa\\Contracts\\ProductCatalog\\Iterator\\BatchIteratorAdapter\\RegionFetchAdapter',
         ],
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\FormBuilder\DependencyInjection\Configuration',
+                'TREE_ROOT',
+                'Ibexa\Bundle\FormBuilder\DependencyInjection\IbexaFormBuilderExtension',
+                'EXTENSION_NAME'
+            ),
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -115,4 +115,16 @@ return static function (RectorConfig $rectorConfig): void {
             'Ibexa\Cart\Money\MoneyFactory' => 'Ibexa\ProductCatalog\Money\IntlMoneyFactory',
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\SiteFactory\DependencyInjection\Configuration',
+                'TREE_ROOT',
+                'Ibexa\Bundle\SiteFactory\DependencyInjection\IbexaSiteFactoryExtension',
+                'EXTENSION_NAME'
+            ),
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -9,7 +9,38 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Rector\Sets;
 
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Renaming\ValueObject\RenameProperty;
 
 return static function (RectorConfig $rectorConfig): void {
     // List of rector rules to upgrade Ibexa projects to Ibexa DXP 4.6
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassConstFetch(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector',
+                'CONTENT_PACKAGES',
+                'HEADLESS_PACKAGES'
+            ),
+            new RenameClassConstFetch(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector',
+                'ENTERPRISE_PACKAGES',
+                'HEADLESS_PACKAGES'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo',
+                'stability',
+                'lowestStability',
+            ),
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -202,4 +202,22 @@ return static function (RectorConfig $rectorConfig): void {
             'Ibexa\Bundle\Core\Imagine\VariationPathGenerator' => 'Ibexa\Contracts\Core\Variation\VariationPathGenerator',
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
+        'Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType' => [
+            'isContainer' => 'isContainer',
+        ],
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
+        'Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft' => [
+            'isContainer' => 'isContainer',
+        ],
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
+        'Ibexa\Core\Repository\Values\ContentType\ContentTypeDraft' => [
+            'isContainer' => 'isContainer',
+        ],
+    ]);
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Rector\Sets;
 
-enum IbexaSetList: string
-{
-    case IBEXA_46 = __DIR__ . '/ibexa-46.php';
-    case IBEXA_50 = __DIR__ . '/ibexa-50.php';
-}
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    // List of rector rules to upgrade Ibexa projects to Ibexa DXP 4.6
+};

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Rector\Sets;
 
+use Ibexa\Rector\Rule\PropertyToGetterRector;
 use Ibexa\Rector\Rule\RemoveArgumentFromMethodCallRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
@@ -89,6 +90,21 @@ return static function (RectorConfig $rectorConfig): void {
                 'Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension',
                 'EXTENSION_NAME'
             ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        PropertyToGetterRector::class,
+        [
+            'Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest' => [
+                'scheme' => 'getScheme',
+                'host' => 'getHost',
+                'port' => 'getPort',
+                'pathinfo' => 'getPathInfo',
+                'queryParams' => 'getQueryParams',
+                'languages' => 'getLanguages',
+                'headers' => 'getHeaders',
+            ],
         ]
     );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -159,4 +159,18 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Solr\\Gateway\\UpdateSerializer' => 'Ibexa\\Solr\\Gateway\\UpdateSerializer\\XmlUpdateSerializer',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Solr\\Query\\Content\\CriterionVisitor\\Field' => 'Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\Field',
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -13,6 +13,7 @@ use Ibexa\Rector\Rule\RemoveArgumentFromMethodCallRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
@@ -105,6 +106,13 @@ return static function (RectorConfig $rectorConfig): void {
                 'languages' => 'getLanguages',
                 'headers' => 'getHeaders',
             ],
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\Cart\Money\MoneyFactory' => 'Ibexa\ProductCatalog\Money\IntlMoneyFactory',
         ]
     );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -8,9 +8,12 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Rector\Sets;
 
+use Ibexa\Rector\Rule\RemoveArgumentFromMethodCallRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Renaming\ValueObject\RenameProperty;
 
@@ -41,6 +44,32 @@ return static function (RectorConfig $rectorConfig): void {
                 'stability',
                 'lowestStability',
             ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [
+            new MethodCallRename(
+                'Ibexa\Contracts\Rest\Output\Generator',
+                'generateMediaType',
+                'generateMediaTypeWithVendor'
+            ),
+            new MethodCallRename(
+                'Ibexa\Rest\Output\FieldTypeSerializer',
+                'serializeFieldValue',
+                'serializeContentFieldValue'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RemoveArgumentFromMethodCallRector::class,
+        [
+            'class_name' => 'Ibexa\Rest\Output\FieldTypeSerializer',
+            'method_name' => 'serializeContentFieldValue',
+            'argument_index_to_remove' => 1,
+            'more_than' => 2,
         ]
     );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -14,6 +14,7 @@ use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Renaming\ValueObject\RenameProperty;
 
@@ -70,6 +71,24 @@ return static function (RectorConfig $rectorConfig): void {
             'method_name' => 'serializeContentFieldValue',
             'argument_index_to_remove' => 1,
             'more_than' => 2,
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass',
+                'EXTENSION_CONFIG_KEY',
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension',
+                'EXTENSION_NAME'
+            ),
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\AbstractConfigurationAwareCompilerPass',
+                'EXTENSION_CONFIG_KEY',
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension',
+                'EXTENSION_NAME'
+            ),
         ]
     );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -184,4 +184,15 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult',
+                'spellSuggestion',
+                'spellcheck',
+            ),
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -147,4 +147,16 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Migration\ValueObject\ContentType\Matcher',
+                'CONTENT_TYPE_IDENTIFIER',
+                'Ibexa\Migration\StepExecutor\ContentType\IdentifierFinder',
+                'CONTENT_TYPE_IDENTIFIER'
+            ),
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -173,4 +173,15 @@ return static function (RectorConfig $rectorConfig): void {
             'Ibexa\\Solr\\Query\\Content\\CriterionVisitor\\Field' => 'Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\Field',
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Contracts\Core\Repository\Values\Content\Trash\SearchResult',
+                'count',
+                'totalCount',
+            ),
+        ]
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -127,4 +127,12 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Bundle\\Shipping\\Form\\Type\\RegionChoiceType' => 'Ibexa\\Bundle\\ProductCatalog\\Form\\Type\\RegionChoiceType',
+            'Ibexa\\Contracts\\Shipping\\Iterator\\BatchIteratorAdapter\\RegionFetchAdapter' => 'Ibexa\\Contracts\\ProductCatalog\\Iterator\\BatchIteratorAdapter\\RegionFetchAdapter',
+        ],
+    );
 };

--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -195,4 +195,11 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\Bundle\Core\Imagine\VariationPathGenerator' => 'Ibexa\Contracts\Core\Variation\VariationPathGenerator',
+        ]
+    );
 };

--- a/tests/lib/Sets/AbstractIbexaRectorSetTestCase.php
+++ b/tests/lib/Sets/AbstractIbexaRectorSetTestCase.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Sets;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+abstract class AbstractIbexaRectorSetTestCase extends AbstractRectorTestCase
+{
+    abstract protected static function getCurrentDirectory(): string;
+
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(static::getCurrentDirectory() . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return static::getCurrentDirectory() . '/config/configured_rule.php';
+    }
+}

--- a/tests/lib/Sets/Ibexa46/Fixture/cart_money_factory.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/cart_money_factory.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Cart\Money\MoneyFactory;
+
+readonly class Foo
+{
+    private MoneyFactory $moneyFactory;
+
+    public function __construct(MoneyFactory $moneyFactory)
+    {
+        $this->moneyFactory = $moneyFactory;
+    }
+
+    public function fooBar(MoneyFactory $moneyFactory): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\ProductCatalog\Money\IntlMoneyFactory;
+
+readonly class Foo
+{
+    private IntlMoneyFactory $moneyFactory;
+
+    public function __construct(IntlMoneyFactory $moneyFactory)
+    {
+        $this->moneyFactory = $moneyFactory;
+    }
+
+    public function fooBar(IntlMoneyFactory $moneyFactory): void
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/change_property_to_method_content_type_draft_is_container.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/change_property_to_method_content_type_draft_is_container.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer()];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/change_property_to_method_content_type_is_container.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/change_property_to_method_content_type_is_container.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+
+readonly class Foo
+{
+    public function foo(ContentType $contentType): array
+    {
+        return [$contentType->isContainer];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+
+readonly class Foo
+{
+    public function foo(ContentType $contentType): array
+    {
+        return [$contentType->isContainer()];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/change_property_to_method_contracts_content_type_draft_is_container.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/change_property_to_method_contracts_content_type_draft_is_container.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer()];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/fieldtype_page_const.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/fieldtype_page_const.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;
 
@@ -19,7 +19,7 @@ class Foo {
 -----
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension;
 use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;

--- a/tests/lib/Sets/Ibexa46/Fixture/fieldtype_page_const.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/fieldtype_page_const.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;
+
+class Foo {
+    public function foo(): array
+    {
+        return [
+            BlockDefinitionConfigurationCompilerPass::EXTENSION_CONFIG_KEY,
+            \Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\AbstractConfigurationAwareCompilerPass::EXTENSION_CONFIG_KEY
+        ];
+    }
+
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension;
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;
+
+class Foo {
+    public function foo(): array
+    {
+        return [
+            IbexaFieldTypePageExtension::EXTENSION_NAME,
+            IbexaFieldTypePageExtension::EXTENSION_NAME
+        ];
+    }
+
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_class_update_serializer.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_class_update_serializer.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Gateway\UpdateSerializer;
+
+readonly class Foo
+{
+    public function __construct(UpdateSerializer $updateSerializer)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Gateway\UpdateSerializer\XmlUpdateSerializer;
+
+readonly class Foo
+{
+    public function __construct(XmlUpdateSerializer $updateSerializer)
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_const_content_type_identifier.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_const_content_type_identifier.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Migration\ValueObject\ContentType\Matcher;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return Matcher::CONTENT_TYPE_IDENTIFIER;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Migration\StepExecutor\ContentType\IdentifierFinder;
+use Ibexa\Migration\ValueObject\ContentType\Matcher;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return IdentifierFinder::CONTENT_TYPE_IDENTIFIER;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_const_tree_root.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_const_tree_root.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Bundle\FormBuilder\DependencyInjection\Configuration;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return Configuration::TREE_ROOT;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Bundle\FormBuilder\DependencyInjection\IbexaFormBuilderExtension;
+use Ibexa\Bundle\FormBuilder\DependencyInjection\Configuration;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return IbexaFormBuilderExtension::EXTENSION_NAME;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_field_namespace_content_to_common.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_field_namespace_content_to_common.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Query\Content\CriterionVisitor\Field;
+
+readonly class Foo
+{
+    public function __construct(Field $field)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Query\Common\CriterionVisitor\Field;
+
+readonly class Foo
+{
+    public function __construct(Field $field)
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_property_searchresult_count.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_property_searchresult_count.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Trash\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): string
+    {
+        return $searchResult->count;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Trash\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): string
+    {
+        return $searchResult->totalCount;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_property_searchresult_spell_suggestion.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_property_searchresult_spell_suggestion.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): array
+    {
+        return [$searchResult->spellSuggestion];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): array
+    {
+        return [$searchResult->spellcheck];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_variation_interface.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_variation_interface.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 
@@ -12,7 +12,7 @@ class SomeFormatVariationGenerator implements VariationPathGenerator
 -----
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 

--- a/tests/lib/Sets/Ibexa46/Fixture/rename_variation_interface.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rename_variation_interface.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
+
+class SomeFormatVariationGenerator implements VariationPathGenerator
+{
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
+
+class SomeFormatVariationGenerator implements VariationPathGenerator
+{
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rest_rename.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rest_rename.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Rest\Output\Generator;
+use Ibexa\Rest\Output\FieldTypeSerializer;
+
+class Foo {
+    public function mediaTypeGenerator(): void
+    {
+        $generator = new Generator();
+
+        return $generator->generateMediaType('name', 'type');
+    }
+
+    public function fieldTypeSerializer(): void
+    {
+        $serializer = new FieldTypeSerializer();
+
+        $generator = new Generator();
+        $contentType = new ContentType();
+        $field = new Field();
+
+        return $serializer->serializeFieldValue($generator, $contentType, $field);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Rest\Output\Generator;
+use Ibexa\Rest\Output\FieldTypeSerializer;
+
+class Foo {
+    public function mediaTypeGenerator(): void
+    {
+        $generator = new Generator();
+
+        return $generator->generateMediaTypeWithVendor('name', 'type');
+    }
+
+    public function fieldTypeSerializer(): void
+    {
+        $serializer = new FieldTypeSerializer();
+
+        $generator = new Generator();
+        $contentType = new ContentType();
+        $field = new Field();
+
+        return $serializer->serializeContentFieldValue($generator, $field);
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/rest_rename.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rest_rename.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
@@ -31,7 +31,7 @@ class Foo {
 -----
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;

--- a/tests/lib/Sets/Ibexa46/Fixture/simplified_request_properties.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/simplified_request_properties.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
+
+$request = new SimplifiedRequest();
+$pathInfo = $request->pathinfo;
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
+
+$request = new SimplifiedRequest();
+$pathInfo = $request->getPathInfo();
+
+?>

--- a/tests/lib/Sets/Ibexa46/Fixture/simplified_request_properties.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/simplified_request_properties.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 
@@ -11,7 +11,7 @@ $pathInfo = $request->pathinfo;
 -----
 <?php
 
-namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+namespace Ibexa\Rector\Tests\Sets\Ibexa46\Fixture;
 
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 

--- a/tests/lib/Sets/Ibexa46/Ibexa46Test.php
+++ b/tests/lib/Sets/Ibexa46/Ibexa46Test.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa46;
+
+use Ibexa\Rector\Tests\Sets\AbstractIbexaRectorSetTestCase;
+
+final class Ibexa46Test extends AbstractIbexaRectorSetTestCase
+{
+    protected static function getCurrentDirectory(): string
+    {
+        return __DIR__;
+    }
+}

--- a/tests/lib/Sets/Ibexa46/config/configured_rule.php
+++ b/tests/lib/Sets/Ibexa46/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([IbexaSetList::IBEXA_46->value]);
+    $rectorConfig->importNames();
+};

--- a/tests/lib/Sets/Ibexa50/Ibexa50Test.php
+++ b/tests/lib/Sets/Ibexa50/Ibexa50Test.php
@@ -8,24 +8,12 @@ declare(strict_types=1);
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50;
 
-use PHPUnit\Framework\Attributes\DataProvider;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Ibexa\Rector\Tests\Sets\AbstractIbexaRectorSetTestCase;
 
-final class Ibexa50Test extends AbstractRectorTestCase
+final class Ibexa50Test extends AbstractIbexaRectorSetTestCase
 {
-    #[DataProvider('provideData')]
-    public function test(string $filePath): void
+    protected static function getCurrentDirectory(): string
     {
-        $this->doTestFile($filePath);
-    }
-
-    public static function provideData(): \Iterator
-    {
-        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
-    }
-
-    public function provideConfigFilePath(): string
-    {
-        return __DIR__ . '/config/configured_rule.php';
+        return __DIR__;
     }
 }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/recipes-dev/pull/152
- https://github.com/ibexa/rector/pull/31

#### Description:

To enable Partner Developers to adopt Ibexa Rector earlier and address deprecations already present in Ibexa 4.6, we've decided to introduce a Rector set specifically for version 4.6. Initially, it will be mostly a copy of the 5.0 set, but over time, the two will diverge.

The downside is of course code duplication. Do we have other ideas how to avoid it?

##### Backports from 5.0.x-dev (main) into 4.6 set:

- [x] #5
- [x] #9
- [x] #10
- [x] #11
- [x] #13
- [x] #17
- [x] #19
- [x] #18
- [x] #20
- [x] #21
- [x] #23
- [x] #22
- [x] #14
- [x] #31 
- [x] #25