### PR TITLE
Added rector rules and configuration for rest parser typehint change

### DIFF
--- a/src/contracts/Sets/ibexa-46.php
+++ b/src/contracts/Sets/ibexa-46.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Rector\Sets;
 
+use Ibexa\Rector\Rule\AddReturnTypeFromParentMethodRule;
+use Ibexa\Rector\Rule\AddReturnTypeFromPhpDocRule;
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
 use Ibexa\Rector\Rule\PropertyToGetterRector;
 use Ibexa\Rector\Rule\RemoveArgumentFromMethodCallRector;
 use Rector\Config\RectorConfig;
@@ -220,4 +223,24 @@ return static function (RectorConfig $rectorConfig): void {
             'isContainer' => 'isContainer',
         ],
     ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromPhpDocRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Contracts\Rest\Input\Parser',
+                'parse'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromParentMethodRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Contracts\Rest\Input\Parser',
+                'parse'
+            ),
+        ]
+    );
 };

--- a/src/lib/Rule/AddReturnTypeFromParentMethodRule.php
+++ b/src/lib/Rule/AddReturnTypeFromParentMethodRule.php
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class AddReturnTypeFromParentMethodRule extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var MethodReturnTypeConfiguration[]
+     * @var \Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration[]
      */
     private array $methodConfigurations = [];
 
@@ -75,29 +75,6 @@ final class AddReturnTypeFromParentMethodRule extends AbstractRector implements 
         return [ClassMethod::class];
     }
 
-    private function isConfiguredParent(ClassReflection $currentClass): bool
-    {
-        foreach ($this->methodConfigurations as $methodConfiguration) {
-            // Check if current class extends configured class
-            $parentClass = $currentClass->getParentClass();
-            while ($parentClass !== null) {
-                if ($parentClass->getName() === $methodConfiguration->getClass()) {
-                    return true;
-                }
-                $parentClass = $parentClass->getParentClass();
-            }
-
-            // Check if current class implements configured interface
-            foreach ($currentClass->getInterfaces() as $interface) {
-                if ($interface->getName() === $methodConfiguration->getClass()) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     private function getMethodReturnTypeFromConfiguredParent(ClassReflection $currentClass, string $methodName): ?string
     {
         foreach ($this->methodConfigurations as $methodConfiguration) {
@@ -112,7 +89,7 @@ final class AddReturnTypeFromParentMethodRule extends AbstractRector implements 
                 if ($classReflection->getName() === $configuredClass) {
                     $method = $classReflection->getNativeMethod($methodName);
                     $variants = $method->getVariants();
-                    if (isset($variants[0]) && $variants[0]->getReturnType()) {
+                    if (isset($variants[0])) {
                         return $variants[0]->getReturnType()->describe(VerbosityLevel::typeOnly());
                     }
                 }
@@ -124,7 +101,7 @@ final class AddReturnTypeFromParentMethodRule extends AbstractRector implements 
                 if ($interface->getName() === $configuredClass) {
                     $method = $interface->getNativeMethod($methodName);
                     $variants = $method->getVariants();
-                    if (isset($variants[0]) && $variants[0]->getReturnType()) {
+                    if (isset($variants[0])) {
                         return $variants[0]->getReturnType()->describe(VerbosityLevel::typeOnly());
                     }
                 }
@@ -152,6 +129,7 @@ final class AddReturnTypeFromParentMethodRule extends AbstractRector implements 
         }
 
         $node->returnType = new Node\Name($typeName);
+
         return $node;
     }
 

--- a/src/lib/Rule/AddReturnTypeFromParentMethodRule.php
+++ b/src/lib/Rule/AddReturnTypeFromParentMethodRule.php
@@ -32,31 +32,31 @@ final class AddReturnTypeFromParentMethodRule extends AbstractRector implements 
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
-                    interface SomeInterface
-                    {
-                        public function someFunction(): SomeObject;
-                    }
-                    
-                    class SomeClass implements SomeInterface
-                    {
-                        public function someFunction()
+                        interface SomeInterface
                         {
+                            public function someFunction(): SomeObject;
                         }
+                        
+                        class SomeClass implements SomeInterface
+                        {
+                            public function someFunction()
+                            {
+                            }
                     }
                     CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-                    interface SomeInterface
-                    {
-                        public function someFunction(): SomeObject;
-                    }
-                    
-                    class SomeClass implements SomeInterface
-                    {
-                        public function someFunction(): SomeObject
+                        interface SomeInterface
                         {
+                            public function someFunction(): SomeObject;
                         }
-                    }
+                        
+                        class SomeClass implements SomeInterface
+                        {
+                            public function someFunction(): SomeObject
+                            {
+                            }
+                        }
                     CODE_SAMPLE
                     ,
                     [

--- a/src/lib/Rule/AddReturnTypeFromParentMethodRule.php
+++ b/src/lib/Rule/AddReturnTypeFromParentMethodRule.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Rule;
+
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
+use PHPStan\Type\VerbosityLevel;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddReturnTypeFromParentMethodRule extends AbstractRector implements ConfigurableRectorInterface
+{
+    private ?MethodReturnTypeConfiguration $methodConfiguration = null;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add return type from parent class or interface method implementation',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+                    interface SomeInterface
+                    {
+                        public function someFunction(): SomeObject;
+                    }
+                    
+                    class SomeClass implements SomeInterface
+                    {
+                        public function someFunction()
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                    interface SomeInterface
+                    {
+                        public function someFunction(): SomeObject;
+                    }
+                    
+                    class SomeClass implements SomeInterface
+                    {
+                        public function someFunction(): SomeObject
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    [
+                        new MethodReturnTypeConfiguration(
+                            'SomeInterface',
+                            'someFunction'
+                        ),
+                    ]
+                ),
+            ]
+        );
+    }
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    private function getMethodReturnType($classOrInterface, string $methodName): ?string
+    {
+        if ($classOrInterface->getName() !== $this->methodConfiguration->getClass()
+            || $methodName !== $this->methodConfiguration->getMethod()) {
+            return null;
+        }
+
+        $method = $classOrInterface->getNativeMethod($methodName);
+        if (!$method) {
+            return null;
+        }
+
+        $variants = $method->getVariants();
+        if (!isset($variants[0])) {
+            return null;
+        }
+
+        $returnType = $variants[0]->getReturnType();
+        if (!$returnType) {
+            return null;
+        }
+
+        return $returnType->describe(VerbosityLevel::typeOnly());
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof ClassMethod || $node->returnType !== null) {
+            return null;
+        }
+
+        $methodName = $this->getName($node);
+        if (!$methodName) {
+            return null;
+        }
+
+        $currentClass = $node->getAttribute('scope')->getClassReflection();
+        if (!$currentClass) {
+            return null;
+        }
+
+        // Check parent classes
+        $parentClass = $currentClass->getParentClass();
+        if ($parentClass) {
+            $typeName = $this->getMethodReturnType($parentClass, $methodName);
+            if ($typeName) {
+                $node->returnType = new Node\Name($typeName);
+                return $node;
+            }
+        }
+
+        // Check interfaces
+        foreach ($currentClass->getInterfaces() as $interface) {
+            $typeName = $this->getMethodReturnType($interface, $methodName);
+            if ($typeName) {
+                $node->returnType = new Node\Name($typeName);
+                return $node;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param MethodReturnTypeConfiguration[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $this->methodConfiguration = $configuration[0];
+    }
+}

--- a/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
+++ b/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
@@ -48,35 +48,35 @@ final class AddReturnTypeFromPhpDocRule extends AbstractRector implements Config
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
-abstract class BaseClass 
-{
-    /** @return SomeObject */
-    abstract public function someFunction();
-}
-
-class SomeClass extends BaseClass
-{
-    /** @return SomeObject */
-    public function someFunction()
-    {
-    }
-}
-CODE_SAMPLE
+                        abstract class BaseClass 
+                        {
+                            /** @return SomeObject */
+                            abstract public function someFunction();
+                        }
+                        
+                        class SomeClass extends BaseClass
+                        {
+                            /** @return SomeObject */
+                            public function someFunction()
+                            {
+                            }
+                        }
+                    CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-abstract class BaseClass 
-{
-    /** @return SomeObject */
-    abstract public function someFunction();
-}
-
-class SomeClass extends BaseClass
-{
-    public function someFunction(): SomeObject
-    {
-    }
-}
-CODE_SAMPLE
+                        abstract class BaseClass 
+                        {
+                            /** @return SomeObject */
+                            abstract public function someFunction();
+                        }
+                        
+                        class SomeClass extends BaseClass
+                        {
+                            public function someFunction(): SomeObject
+                            {
+                            }
+                        }
+                    CODE_SAMPLE
                     ,
                     [
                         new MethodReturnTypeConfiguration(

--- a/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
+++ b/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\MixedType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddReturnTypeFromPhpDocRule extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var MethodReturnTypeConfiguration[]
+     */
+    private array $methodConfigurations = [];
+
+    public function __construct(
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add return type to methods based on their PHPDoc return tag',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+                    class SomeClass
+                    {
+                        /** @return SomeObject */
+                        public function someFunction()
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                    class SomeClass
+                    {
+                        public function someFunction(): SomeObject
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                    ,
+                    [
+                        'configurations' => [
+                            new MethodReturnTypeConfiguration(
+                                'SomeInterface',
+                                'someFunction',
+                            ),
+                        ],
+                    ]
+                ),
+            ]
+        );
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->returnType !== null) {
+            return null;
+        }
+
+        $currentClass = $node->getAttribute('scope')->getClassReflection();
+        if (!$currentClass) {
+            return null;
+        }
+
+        $methodName = $this->getName($node);
+        if ($methodName === null) {
+            return null;
+        }
+
+        foreach ($this->methodConfigurations as $config) {
+            foreach ($currentClass->getInterfaces() as $interface) {
+                if ($interface->getName() === $config->getClass() && $methodName === $config->getMethod()) {
+                    $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+                    $returnType = $phpDocInfo->getReturnType();
+
+                    if (!$returnType instanceof MixedType) {
+                        $node->returnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+                        return $node;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $this->methodConfigurations = $configuration;
+    }
+}

--- a/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
+++ b/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
@@ -46,31 +46,41 @@ final class AddReturnTypeFromPhpDocRule extends AbstractRector implements Config
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
-                    class SomeClass
-                    {
-                        /** @return SomeObject */
-                        public function someFunction()
-                        {
-                        }
-                    }
-                    CODE_SAMPLE
+abstract class BaseClass 
+{
+    /** @return SomeObject */
+    abstract public function someFunction();
+}
+
+class SomeClass extends BaseClass
+{
+    /** @return SomeObject */
+    public function someFunction()
+    {
+    }
+}
+CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-                    class SomeClass
-                    {
-                        public function someFunction(): SomeObject
-                        {
-                        }
-                    }
-                    CODE_SAMPLE
+abstract class BaseClass 
+{
+    /** @return SomeObject */
+    abstract public function someFunction();
+}
+
+class SomeClass extends BaseClass
+{
+    public function someFunction(): SomeObject
+    {
+    }
+}
+CODE_SAMPLE
                     ,
                     [
-                        'configurations' => [
-                            new MethodReturnTypeConfiguration(
-                                'SomeInterface',
-                                'someFunction',
-                            ),
-                        ],
+                        new MethodReturnTypeConfiguration(
+                            'BaseClass',
+                            'someFunction',
+                        ),
                     ]
                 ),
             ]
@@ -113,10 +123,17 @@ final class AddReturnTypeFromPhpDocRule extends AbstractRector implements Config
     private function findMatchingConfiguration(ClassReflection $currentClass, string $methodName): ?MethodReturnTypeConfiguration
     {
         foreach ($this->methodConfigurations as $config) {
+            // Check interfaces
             foreach ($currentClass->getInterfaces() as $interface) {
                 if ($interface->getName() === $config->getClass() && $methodName === $config->getMethod()) {
                     return $config;
                 }
+            }
+
+            // Check parent class
+            $parentClass = $currentClass->getParentClass();
+            if ($parentClass && $parentClass->getName() === $config->getClass() && $methodName === $config->getMethod()) {
+                return $config;
             }
         }
 

--- a/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
+++ b/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
@@ -1,25 +1,29 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace Ibexa\Rector\Rule;
 
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\MixedType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
-use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\StaticTypeMapper\StaticTypeMapper;
-use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class AddReturnTypeFromPhpDocRule extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var MethodReturnTypeConfiguration[]
+     * @var \Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration[]
      */
     private array $methodConfigurations = [];
 
@@ -72,6 +76,9 @@ final class AddReturnTypeFromPhpDocRule extends AbstractRector implements Config
         );
     }
 
+    /**
+     * @param \PhpParser\Node\Stmt\ClassMethod $node
+     */
     public function refactor(Node $node): ?Node
     {
         if ($node->returnType !== null) {
@@ -84,9 +91,6 @@ final class AddReturnTypeFromPhpDocRule extends AbstractRector implements Config
         }
 
         $methodName = $this->getName($node);
-        if ($methodName === null) {
-            return null;
-        }
 
         foreach ($this->methodConfigurations as $config) {
             foreach ($currentClass->getInterfaces() as $interface) {
@@ -96,6 +100,7 @@ final class AddReturnTypeFromPhpDocRule extends AbstractRector implements Config
 
                     if (!$returnType instanceof MixedType) {
                         $node->returnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+
                         return $node;
                     }
                 }

--- a/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
+++ b/src/lib/Rule/AddReturnTypeFromPhpDocRule.php
@@ -10,8 +10,10 @@ namespace Ibexa\Rector\Rule;
 
 use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
 use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
@@ -24,7 +26,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class AddReturnTypeFromPhpDocRule extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var MethodReturnTypeConfiguration[]
+     * @var \Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration[]
      */
     private array $methodConfigurations = [];
 
@@ -87,7 +89,7 @@ CODE_SAMPLE
         );
     }
 
-    private function getReturnTypeFromPhpDoc(ClassMethod $node, string $methodName): ?Node\Name
+    private function getReturnTypeFromPhpDoc(ClassMethod $node, string $methodName): ComplexType|Identifier|Name|null
     {
         foreach ($this->methodConfigurations as $methodConfiguration) {
             if ($methodName !== $methodConfiguration->getMethod()) {
@@ -136,9 +138,6 @@ CODE_SAMPLE
         }
 
         $methodName = $this->getName($node);
-        if ($methodName === null) {
-            return null;
-        }
 
         $returnType = $this->getReturnTypeFromPhpDoc($node, $methodName);
         if ($returnType === null) {
@@ -146,11 +145,12 @@ CODE_SAMPLE
         }
 
         $node->returnType = $returnType;
+
         return $node;
     }
 
     /**
-     * @param MethodReturnTypeConfiguration[] $configuration
+     * @param \Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration[] $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/lib/Rule/Configuration/MethodReturnTypeConfiguration.php
+++ b/src/lib/Rule/Configuration/MethodReturnTypeConfiguration.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Rule\Configuration;
+
+final readonly class MethodReturnTypeConfiguration
+{
+    public function __construct(
+        private string $class,
+        private string $method,
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+}

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/AddReturnTypeFromParentMethodRuleTest.php
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/AddReturnTypeFromParentMethodRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddReturnTypeFromParentMethodRuleTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/AddReturnTypeFromParentMethodRuleTest.php
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/AddReturnTypeFromParentMethodRuleTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule;

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/Fixture/some_class.php.inc
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/Fixture/some_class.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture;
+
+interface SomeInterface
+{
+    public function someFunction(): SomeObject;
+}
+
+class SomeClass implements SomeInterface
+{
+    public function someFunction()
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture;
+
+interface SomeInterface
+{
+    public function someFunction(): SomeObject;
+}
+
+class SomeClass implements SomeInterface
+{
+    public function someFunction(): Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture\SomeObject
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/Fixture/some_class_with_abstract.php.inc
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/Fixture/some_class_with_abstract.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture;
+
+abstract class SomeMiddleAbstract extends SomeAbstract
+{
+}
+
+abstract class SomeAbstract
+{
+    abstract public function someFunction(): mixed;
+}
+
+class SomeClass extends SomeMiddleAbstract
+{
+    public function someFunction()
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture;
+
+abstract class SomeMiddleAbstract extends SomeAbstract
+{
+}
+
+abstract class SomeAbstract
+{
+    abstract public function someFunction(): mixed;
+}
+
+class SomeClass extends SomeMiddleAbstract
+{
+    public function someFunction(): mixed
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/config/configured_rule.php
@@ -18,6 +18,10 @@ return static function (RectorConfig $rectorConfig): void {
                 'Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture\SomeInterface',
                 'someFunction'
             ),
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture\SomeAbstract',
+                'someFunction'
+            ),
         ]
     );
 };

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/config/configured_rule.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 use Ibexa\Rector\Rule\AddReturnTypeFromParentMethodRule;

--- a/tests/lib/Rule/AddReturnTypeFromParentMethodRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromParentMethodRule/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Ibexa\Rector\Rule\AddReturnTypeFromParentMethodRule;
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromParentMethodRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Rector\Tests\Rule\AddReturnTypeFromParentMethodRule\Fixture\SomeInterface',
+                'someFunction'
+            ),
+        ]
+    );
+};

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/AddReturnTypeFromPhpDocRuleTest.php
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/AddReturnTypeFromPhpDocRuleTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule;

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/AddReturnTypeFromPhpDocRuleTest.php
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/AddReturnTypeFromPhpDocRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddReturnTypeFromPhpDocRuleTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/Fixture/some_class.php.inc
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/Fixture/some_class.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture;
+
+interface SomeInterface
+{
+    public function someFunction(): mixed;
+}
+
+class SomeClass implements SomeInterface
+{
+    /** @return SomeObject */
+    public function someFunction()
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture;
+
+interface SomeInterface
+{
+    public function someFunction(): mixed;
+}
+
+class SomeClass implements SomeInterface
+{
+    /** @return SomeObject */
+    public function someFunction(): \Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeObject
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/Fixture/some_class_with_abstract.php.inc
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/Fixture/some_class_with_abstract.php.inc
@@ -2,12 +2,16 @@
 
 namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture;
 
-abstract Class SomeAbstract
+abstract class SomeMiddleAbstract extends SomeAbstract
+{
+}
+
+abstract class SomeAbstract
 {
     public function someFunction(): mixed;
 }
 
-class SomeClass extends SomeAbstract
+class SomeClass extends SomeMiddleAbstract
 {
     /** @return SomeObject */
     public function someFunction()
@@ -26,12 +30,16 @@ class SomeObject
 
 namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture;
 
-abstract Class SomeAbstract
+abstract class SomeMiddleAbstract extends SomeAbstract
+{
+}
+
+abstract class SomeAbstract
 {
     public function someFunction(): mixed;
 }
 
-class SomeClass extends SomeAbstract
+class SomeClass extends SomeMiddleAbstract
 {
     /** @return SomeObject */
     public function someFunction(): \Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeObject

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/Fixture/some_class_with_abstract.php.inc
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/Fixture/some_class_with_abstract.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture;
+
+abstract Class SomeAbstract
+{
+    public function someFunction(): mixed;
+}
+
+class SomeClass extends SomeAbstract
+{
+    /** @return SomeObject */
+    public function someFunction()
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture;
+
+abstract Class SomeAbstract
+{
+    public function someFunction(): mixed;
+}
+
+class SomeClass extends SomeAbstract
+{
+    /** @return SomeObject */
+    public function someFunction(): \Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeObject
+    {
+        return new SomeObject();
+    }
+}
+
+class SomeObject
+{
+}
+
+?>

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
@@ -20,4 +20,14 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]
     );
+
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromPhpDocRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeAbstract',
+                'someFunction'
+            ),
+        ]
+    );
 };

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Ibexa\Rector\Rule\AddReturnTypeFromPhpDocRule;
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromPhpDocRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeInterface',
+                'someFunction'
+            ),
+        ]
+    );
+};

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 use Ibexa\Rector\Rule\AddReturnTypeFromPhpDocRule;

--- a/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
+++ b/tests/lib/Rule/AddReturnTypeFromPhpDocRule/config/configured_rule.php
@@ -18,12 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
                 'Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeInterface',
                 'someFunction'
             ),
-        ]
-    );
-
-    $rectorConfig->ruleWithConfiguration(
-        AddReturnTypeFromPhpDocRule::class,
-        [
             new MethodReturnTypeConfiguration(
                 'Ibexa\Rector\Tests\Rule\AddReturnTypeFromPhpDocRule\Fixture\SomeAbstract',
                 'someFunction'

--- a/tests/lib/Sets/Ibexa46/Fixture/rest_parser.php.inc
+++ b/tests/lib/Sets/Ibexa46/Fixture/rest_parser.php.inc
@@ -1,0 +1,79 @@
+<?php
+
+namespace Ibexa\Contracts\Rest\Input;
+
+abstract class BaseParser extends Parser
+{
+}
+
+abstract class Parser
+{
+    abstract public function parse(array $data, ParsingDispatcher $parsingDispatcher): mixed;
+}
+
+?>
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Contracts\Rest\Input\BaseParser;
+use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
+
+class SomeParserWithDoc extends BaseParser
+{
+    /**
+     * @return \stdClass
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+    }
+}
+
+class SomeParserWithoutDoc extends BaseParser
+{
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Contracts\Rest\Input;
+
+abstract class BaseParser extends Parser
+{
+}
+
+abstract class Parser
+{
+    abstract public function parse(array $data, ParsingDispatcher $parsingDispatcher): mixed;
+}
+
+?>
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Contracts\Rest\Input\BaseParser;
+use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
+
+class SomeParserWithDoc extends BaseParser
+{
+    /**
+     * @return \stdClass
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): \stdClass
+    {
+    }
+}
+
+class SomeParserWithoutDoc extends BaseParser
+{
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): mixed
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Issue: https://github.com/ibexa/rest/pull/164/files#diff-00dd56f95f27fd06a498d27b5b1e618153535129020895d4815d870fb4b6b7fdL22

Two rectors with configuration class added:
- in first pass it reads phpdoc in class that extends or implements configured one. If return type is not declared, and there is one in phpdodc it uses is as a native php typehint. Since in REST typehint is set tu `mixed`, it always match as narrowing type is accepted.

- if there is no exsisitng typehint, second rule use native phptypehint from parent (abstract or interface) and use it as native one in child class.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
