### PR TITLE
Remove use of protected property NodeNameResolver on RemoveArgumentFromMethodCallRector

### DIFF
--- a/src/lib/Rule/RemoveArgumentFromMethodCallRector.php
+++ b/src/lib/Rule/RemoveArgumentFromMethodCallRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
         if ($className !== $this->className) {
             return null;
         }
-        if ($this->nodeNameResolver->isName($node->name, $this->methodName)
+        if ($this->isName($node->name, $this->methodName)
             && count($node->args) > $this->moreThan
         ) {
             if (isset($node->args[$this->argumentIndex])) {


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

Rector is removing use of protected property `nodeNameResolver` in rules, use `isName()` directly instead. Ref PR:

- https://github.com/rectorphp/rector-src/pull/6875

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
