### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "require": {
         "php": ">=8.3",
         "rector/rector": "^2.0",
-        "symfony/console": "^7.2",
-        "symfony/finder": "^7.2",
-        "symfony/filesystem": "^7.2"
+        "symfony/console": "^7.3",
+        "symfony/finder": "^7.3",
+        "symfony/filesystem": "^7.3"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

