### PR TITLE
[Symfony 7] Skipped SimplifyFormRenderingRector

### DIFF
--- a/src/contracts/Sets/ibexa-50.php
+++ b/src/contracts/Sets/ibexa-50.php
@@ -25,6 +25,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Renaming\ValueObject\RenameProperty;
+use Rector\Symfony\Symfony62\Rector\MethodCall\SimplifyFormRenderingRector;
 
 return static function (RectorConfig $rectorConfig): void {
     // List of rector rules to upgrade Ibexa projects to Ibexa DXP 5.0
@@ -303,6 +304,13 @@ return static function (RectorConfig $rectorConfig): void {
                 2,
                 'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject'
             ),
+        ]
+    );
+
+    $rectorConfig->skip(
+        [
+            // skip removing `createView` method call from `Form` objects, per SF 7 recommendation
+            SimplifyFormRenderingRector::class,
         ]
     );
 };


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

While Symfony 6 suggested skipping calls to `$form->createView()` and pass directly `$form` object to a template, Symfony 7 reverted that statement due to some edge cases.

However, `SimplifyFormRenderingRector` rule still exists in our configs (coming from general Symfony 6.2 set), because we apply all sets for Symfony 5  to 7. We need to, because we're jumping directly from SF 5 (Ibexa 4.6) to SF 7 (Ibexa 5.0).

Seems adding `skip` is the simplest workaround.