### PR TITLE
Prepared configuration for Ibexa Annotation to Attribute Constraints

### DIFF
--- a/src/contracts/Factory/IbexaRectorConfigFactory.php
+++ b/src/contracts/Factory/IbexaRectorConfigFactory.php
@@ -62,6 +62,7 @@ final readonly class IbexaRectorConfigFactory implements IbexaRectorConfigFactor
                    $this->extraSets
                )
            )
+           ->withAttributesSets(symfony: true, doctrine: true)
         ;
     }
 }

--- a/src/contracts/Factory/IbexaRectorConfigFactoryInterface.php
+++ b/src/contracts/Factory/IbexaRectorConfigFactoryInterface.php
@@ -15,5 +15,8 @@ use Rector\Configuration\RectorConfigBuilder;
  */
 interface IbexaRectorConfigFactoryInterface
 {
+    /**
+     * @throws \Rector\Exception\Configuration\InvalidConfigurationException
+     */
     public function createConfig(): RectorConfigBuilder;
 }

--- a/src/contracts/Sets/ibexa-50.php
+++ b/src/contracts/Sets/ibexa-50.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Rector\Sets;
 
+use Ibexa\Rector\Configuration\AnnotationToAttributeConfigurationBuilder;
 use Ibexa\Rector\Rule\AddReturnTypeFromParentMethodRule;
 use Ibexa\Rector\Rule\AddReturnTypeFromPhpDocRule;
 use Ibexa\Rector\Rule\ChangeArgumentTypeRector;
@@ -17,6 +18,7 @@ use Ibexa\Rector\Rule\ConstToEnumValueRector;
 use Ibexa\Rector\Rule\PropertyToGetterRector;
 use Ibexa\Rector\Rule\RemoveArgumentFromMethodCallRector;
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -305,6 +307,10 @@ return static function (RectorConfig $rectorConfig): void {
                 'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject'
             ),
         ]
+    );
+    $rectorConfig->ruleWithConfiguration(
+        AnnotationToAttributeRector::class,
+        iterator_to_array((new AnnotationToAttributeConfigurationBuilder())->build())
     );
 
     $rectorConfig->skip(

--- a/src/lib/Configuration/AnnotationToAttributeConfigurationBuilder.php
+++ b/src/lib/Configuration/AnnotationToAttributeConfigurationBuilder.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Configuration;
+
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+final class AnnotationToAttributeConfigurationBuilder
+{
+    /**
+     * @return iterable<\Rector\Php80\ValueObject\AnnotationToAttribute>
+     */
+    public function build(): iterable
+    {
+        foreach (IbexaSymfonyConstraintList::cases() as $constraintFQCN) {
+            yield new AnnotationToAttribute($constraintFQCN->value);
+        }
+    }
+}

--- a/src/lib/Configuration/AnnotationToAttributeConfigurationBuilder.php
+++ b/src/lib/Configuration/AnnotationToAttributeConfigurationBuilder.php
@@ -10,7 +10,7 @@ namespace Ibexa\Rector\Configuration;
 
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 
-final class AnnotationToAttributeConfigurationBuilder
+final readonly class AnnotationToAttributeConfigurationBuilder
 {
     /**
      * @return iterable<\Rector\Php80\ValueObject\AnnotationToAttribute>

--- a/src/lib/Configuration/IbexaSymfonyConstraintList.php
+++ b/src/lib/Configuration/IbexaSymfonyConstraintList.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Configuration;
+
+enum IbexaSymfonyConstraintList: string
+{
+    // Segmentation
+    case SegmentationUserToSegmentAssignment = 'Ibexa\Segmentation\Validation\Constraint\UserToSegmentAssignment';
+    case SegmentationUniqueSegmentGroupStructIdentifier = 'Ibexa\Segmentation\Validation\Constraint\UniqueSegmentGroupStructIdentifier';
+    case SegmentationUniqueSegmentStructIdentifier = 'Ibexa\Segmentation\Validation\Constraint\UniqueSegmentStructIdentifier';
+
+    // Connector AI
+    case ConnectorAiActionConfigurationHandlerOptions = 'Ibexa\ConnectorAi\Validation\Constraints\ActionConfigurationHandlerOptions';
+    case ConnectorAiActionConfigurationTypeOptions = 'Ibexa\ConnectorAi\Validation\Constraints\ActionConfigurationTypeOptions';
+    case ConnectorAiUniqueActionConfigurationIdentifier = 'Ibexa\ConnectorAi\Validation\Constraints\UniqueActionConfigurationIdentifier';
+    case ConnectorAiIdentifier = 'Ibexa\ConnectorAi\Validation\Constraints\Identifier';
+
+    // Discounts
+    case DiscountsAtLeastOneDiscountTranslationWillRemain = 'Ibexa\Discounts\Validation\Constraint\AtLeastOneDiscountTranslationWillRemain';
+    case DiscountsCountCategories = 'Ibexa\Discounts\Validation\Constraint\CountCategories';
+    case DiscountsCountCustomerGroup = 'Ibexa\Discounts\Validation\Constraint\CountCustomerGroup';
+    case DiscountsCountProducts = 'Ibexa\Discounts\Validation\Constraint\CountProducts';
+    case DiscountsCurrencyRequired = 'Ibexa\Discounts\Validation\Constraint\CurrencyRequired';
+    case DiscountsUniqueIdentifier = 'Ibexa\Discounts\Validation\Constraint\UniqueIdentifier';
+    case DiscountsIdentifier = 'Ibexa\Discounts\Validation\Constraint\Identifier';
+    case DiscountsValidDiscountRuleType = 'Ibexa\Discounts\Validation\Constraint\ValidDiscountRuleType';
+
+    // Collaboration
+    case CollaborationParticipantType = 'Ibexa\Collaboration\Validation\Constraint\ParticipantType';
+    case CollaborationUniqueToken = 'Ibexa\Collaboration\Validation\Constraint\UniqueToken';
+
+    // Payment
+    case PaymentAllowedPaymentStatusTransition = 'Ibexa\Payment\Validation\Constraints\AllowedPaymentStatusTransition';
+    case PaymentAtLeastOneTranslation = 'Ibexa\Payment\Validation\Constraints\AtLeastOneTranslation';
+    case PaymentEnabledPaymentMethod = 'Ibexa\Payment\Validation\Constraints\EnabledPaymentMethod';
+    case PaymentIdentifier = 'Ibexa\Payment\Validation\Constraints\Identifier';
+    case PaymentMoneyAmountEqualToOrGreaterThanZero = 'Ibexa\Payment\Validation\Constraints\MoneyAmountEqualToOrGreaterThanZero';
+    case PaymentPaymentMethodEnabled = 'Ibexa\Payment\Validation\Constraints\PaymentMethodEnabled';
+    case PaymentPaymentMethodOptions = 'Ibexa\Payment\Validation\Constraints\PaymentMethodOptions';
+    case PaymentUniquePaymentIdentifier = 'Ibexa\Payment\Validation\Constraints\UniquePaymentIdentifier';
+    case PaymentUniquePaymentMethodIdentifier = 'Ibexa\Payment\Validation\Constraints\UniquePaymentMethodIdentifier';
+
+    // SiteFactory
+    case SiteFactoryHostnameWithOptionalPort = 'Ibexa\Bundle\SiteFactory\Validator\Constraints\HostnameWithOptionalPort';
+    case SiteFactoryPort = 'Ibexa\Bundle\SiteFactory\Validator\Constraints\Port';
+}

--- a/stubs/Ibexa/Payment/Validation/Constraints/UniquePaymentMethodIdentifier.php
+++ b/stubs/Ibexa/Payment/Validation/Constraints/UniquePaymentMethodIdentifier.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Ibexa\Payment\Validation\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
+final class UniquePaymentMethodIdentifier extends Constraint
+{
+}

--- a/stubs/Ibexa/Payment/Validation/Constraints/UniquePaymentMethodIdentifier.php
+++ b/stubs/Ibexa/Payment/Validation/Constraints/UniquePaymentMethodIdentifier.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace Ibexa\Payment\Validation\Constraints;
 

--- a/stubs/Ibexa/Segmentation/Validation/Constraint/UserToSegmentAssignment.php
+++ b/stubs/Ibexa/Segmentation/Validation/Constraint/UserToSegmentAssignment.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 namespace Ibexa\Segmentation\Validation\Constraint;
 
 use Symfony\Component\Validator\Constraint;

--- a/stubs/Ibexa/Segmentation/Validation/Constraint/UserToSegmentAssignment.php
+++ b/stubs/Ibexa/Segmentation/Validation/Constraint/UserToSegmentAssignment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ibexa\Segmentation\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class UserToSegmentAssignment extends Constraint
+{
+
+}

--- a/tests/lib/Sets/Ibexa50/Fixture/annotation_to_attribute.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/annotation_to_attribute.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Payment\Validation\Constraints\UniquePaymentMethodIdentifier;
+use Ibexa\Segmentation\Validation\Constraint\UserToSegmentAssignment;
+
+/**
+ * @UserToSegmentAssignment()
+ */
+class Foo
+{
+    /** @UniquePaymentMethodIdentifier */
+    public string $uniquePaymentIdentifier;
+
+    /**
+     * @UniquePaymentMethodIdentifier
+     */
+    public function getUniquePaymentIdentifier(): string
+    {
+        return $this->uniquePaymentIdentifier;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Payment\Validation\Constraints\UniquePaymentMethodIdentifier;
+use Ibexa\Segmentation\Validation\Constraint\UserToSegmentAssignment;
+
+#[UserToSegmentAssignment]
+class Foo
+{
+    #[UniquePaymentMethodIdentifier]
+    public string $uniquePaymentIdentifier;
+
+    #[UniquePaymentMethodIdentifier]
+    public function getUniquePaymentIdentifier(): string
+    {
+        return $this->uniquePaymentIdentifier;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa50/Fixture/annotation_to_attribute.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/annotation_to_attribute.php.inc
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
 
@@ -25,6 +26,7 @@ class Foo
 ?>
 -----
 <?php
+declare(strict_types=1);
 
 namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
 


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/segmentation/pull/158

#### Description:

This is a follow up to a merge-up issue where I forgot to refactor Symfony <=5 constraint annotations to Symfony 7 constraint attributes.

The main drawback of the existing rector is that it's an allow-list-based, meaning each specific constraint needs to be configured manually. So this will not protect us from a case where a new custom constraint annotation is added in 4.6, if we forgot to add it to the list here. We should rather consider writing our own rector that would:
1) check if a given annotation is an class
2) check if that class is an attribute with proper context target ideally
3) refactor it in a generic way

For now, the proposed changes protect from regressions when using existing Ibexa constraints. I've extracted that list to an `IbexaSymfonyConstraintList` enum.

