### PR TITLE
Upgrade to use PHP-Parser 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
-        "nikic/php-parser": "^4.18",
+        "nikic/php-parser": "^5.7",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",

--- a/src/lib/Rule/Internal/RemoveDeprecatedTwigDefinitionsRector.php
+++ b/src/lib/Rule/Internal/RemoveDeprecatedTwigDefinitionsRector.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\Rector\Rule\Internal;
 
 use PhpParser\Node;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
@@ -129,8 +129,7 @@ CODE_SAMPLE
                         $optionsArray = $newExpr->args[2]->value;
 
                         foreach ($optionsArray->items as $optionItem) {
-                            if ($optionItem instanceof ArrayItem &&
-                                $optionItem->key instanceof Node\Scalar\String_ &&
+                            if ($optionItem->key instanceof Node\Scalar\String_ &&
                                 $optionItem->key->value === 'deprecated' &&
                                 $optionItem->value instanceof Node\Scalar\String_ &&
                                 $optionItem->value->value === $this->version


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Rector 2.0 uses php-parser 5, make require-dev of php-parser 4 will silent deprecated notice that may not compatible in the future.

the PR upgrade to use php-parser 5 on require-dev and clean up deprecated nodes.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
