### PR TITLE
IBX-11974: Added Rector rule migrating DeduplicateStamp to Contracts namespace

### DIFF
--- a/src/contracts/Sets/ibexa-50.php
+++ b/src/contracts/Sets/ibexa-50.php
@@ -216,6 +216,13 @@ return static function (RectorConfig $rectorConfig): void {
         ]
     );
 
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp' => 'Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp',
+        ]
+    );
+
     $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
         'Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType' => [
             'isContainer' => 'isContainer',

--- a/tests/lib/Sets/Ibexa50/Fixture/rename_class_deduplicate_stamp.php.inc
+++ b/tests/lib/Sets/Ibexa50/Fixture/rename_class_deduplicate_stamp.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampUsage
+{
+    public function createStamp(): DeduplicateStamp
+    {
+        return new DeduplicateStamp('key');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa50\Fixture;
+
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampUsage
+{
+    public function createStamp(): DeduplicateStamp
+    {
+        return new DeduplicateStamp('key');
+    }
+}
+
+?>


### PR DESCRIPTION
| :ticket: Issue | [IBX-11974](https://ibexa.atlassian.net/browse/IBX-11974) |
|----------------|-----------|

#### Description
Adds a Rector rule that automatically migrates references of the deprecated `Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp` to its replacement `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp`.

`DeduplicateStamp` was moved to the Contracts namespace and the Bundle-namespace class was deprecated (ibexa/messenger#20) and removed for the next major (ibexa/messenger#21). This rule lets consumers — internal Ibexa packages and end-user projects alike — update their code base automatically as part of the Ibexa DXP 5.0 upgrade set.

Implemented with Rector's built-in `RenameClassRector`, added to the existing `ibexa-50` set, following the package convention for class moves (`CONTRIBUTING.md`: "new rules should be added there"). Covered by a set fixture under `tests/lib/Sets/Ibexa50/Fixture/`.

#### Related
- ibexa/messenger#21
- ibexa/discounts#334
- ibexa/connector-quable#47
- ibexa/data-intelligence-layer#21


[IBX-11974]: https://ibexa.atlassian.net/browse/IBX-11974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ