### PR TITLE
IBX-12084: Added Ibexa DXP 6.0 rule set with DeduplicateStamp renamed to Symfony Messenger one

### DIFF
--- a/src/contracts/Factory/IbexaRectorConfigFactory.php
+++ b/src/contracts/Factory/IbexaRectorConfigFactory.php
@@ -41,7 +41,7 @@ final readonly class IbexaRectorConfigFactory implements IbexaRectorConfigFactor
            ->withSets(
                array_merge(
                    [
-                       IbexaSetList::IBEXA_50->value,
+                       IbexaSetList::IBEXA_60->value,
                        SymfonySetList::SYMFONY_50,
                        SymfonySetList::SYMFONY_50_TYPES,
                        SymfonySetList::SYMFONY_51,

--- a/src/contracts/Sets/IbexaSetList.php
+++ b/src/contracts/Sets/IbexaSetList.php
@@ -12,4 +12,5 @@ enum IbexaSetList: string
 {
     case IBEXA_46 = __DIR__ . '/ibexa-46.php';
     case IBEXA_50 = __DIR__ . '/ibexa-50.php';
+    case IBEXA_60 = __DIR__ . '/ibexa-60.php';
 }

--- a/src/contracts/Sets/ibexa-60.php
+++ b/src/contracts/Sets/ibexa-60.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Rector\Sets;
+
+use Ibexa\Rector\Rule\AddReturnTypeFromParentMethodRule;
+use Ibexa\Rector\Rule\AddReturnTypeFromPhpDocRule;
+use Ibexa\Rector\Rule\ChangeArgumentTypeRector;
+use Ibexa\Rector\Rule\Configuration\ChangeArgumentTypeConfiguration;
+use Ibexa\Rector\Rule\Configuration\MethodReturnTypeConfiguration;
+use Ibexa\Rector\Rule\ConstToEnumValueRector;
+use Ibexa\Rector\Rule\PropertyToGetterRector;
+use Ibexa\Rector\Rule\RemoveArgumentFromMethodCallRector;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
+use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Renaming\ValueObject\RenameProperty;
+use Rector\Symfony\Symfony62\Rector\MethodCall\SimplifyFormRenderingRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    // List of rector rules to upgrade Ibexa projects to Ibexa DXP 6.0
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Bundle\\Core\\ApiLoader\\RepositoryConfigurationProvider' => 'Ibexa\\Contracts\\Core\\Container\\ApiLoader\\RepositoryConfigurationProviderInterface',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassConstFetch(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector',
+                'CONTENT_PACKAGES',
+                'HEADLESS_PACKAGES'
+            ),
+            new RenameClassConstFetch(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector',
+                'ENTERPRISE_PACKAGES',
+                'HEADLESS_PACKAGES'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo',
+                'stability',
+                'lowestStability',
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [
+            new MethodCallRename(
+                'Ibexa\Contracts\Rest\Output\Generator',
+                'generateMediaType',
+                'generateMediaTypeWithVendor'
+            ),
+            new MethodCallRename(
+                'Ibexa\Rest\Output\FieldTypeSerializer',
+                'serializeFieldValue',
+                'serializeContentFieldValue'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RemoveArgumentFromMethodCallRector::class,
+        [
+            'class_name' => 'Ibexa\Rest\Output\FieldTypeSerializer',
+            'method_name' => 'serializeContentFieldValue',
+            'argument_index_to_remove' => 1,
+            'more_than' => 2,
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass',
+                'EXTENSION_CONFIG_KEY',
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension',
+                'EXTENSION_NAME'
+            ),
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\AbstractConfigurationAwareCompilerPass',
+                'EXTENSION_CONFIG_KEY',
+                'Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension',
+                'EXTENSION_NAME'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        PropertyToGetterRector::class,
+        [
+            'Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest' => [
+                'scheme' => 'getScheme',
+                'host' => 'getHost',
+                'port' => 'getPort',
+                'pathinfo' => 'getPathInfo',
+                'queryParams' => 'getQueryParams',
+                'languages' => 'getLanguages',
+                'headers' => 'getHeaders',
+            ],
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\Cart\Money\MoneyFactory' => 'Ibexa\ProductCatalog\Money\IntlMoneyFactory',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\SiteFactory\DependencyInjection\Configuration',
+                'TREE_ROOT',
+                'Ibexa\Bundle\SiteFactory\DependencyInjection\IbexaSiteFactoryExtension',
+                'EXTENSION_NAME'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Bundle\\Shipping\\Form\\Type\\RegionChoiceType' => 'Ibexa\\Bundle\\ProductCatalog\\Form\\Type\\RegionChoiceType',
+            'Ibexa\\Contracts\\Shipping\\Iterator\\BatchIteratorAdapter\\RegionFetchAdapter' => 'Ibexa\\Contracts\\ProductCatalog\\Iterator\\BatchIteratorAdapter\\RegionFetchAdapter',
+        ],
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Bundle\FormBuilder\DependencyInjection\Configuration',
+                'TREE_ROOT',
+                'Ibexa\Bundle\FormBuilder\DependencyInjection\IbexaFormBuilderExtension',
+                'EXTENSION_NAME'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch(
+                'Ibexa\Migration\ValueObject\ContentType\Matcher',
+                'CONTENT_TYPE_IDENTIFIER',
+                'Ibexa\Migration\StepExecutor\ContentType\IdentifierFinder',
+                'CONTENT_TYPE_IDENTIFIER'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Solr\\Gateway\\UpdateSerializer' => 'Ibexa\\Solr\\Gateway\\UpdateSerializer\\XmlUpdateSerializer',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\\Solr\\Query\\Content\\CriterionVisitor\\Field' => 'Ibexa\\Solr\\Query\\Common\\CriterionVisitor\\Field',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Contracts\Core\Repository\Values\Content\Trash\SearchResult',
+                'count',
+                'totalCount',
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [
+            new RenameProperty(
+                'Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult',
+                'spellSuggestion',
+                'spellcheck',
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\Bundle\Core\Imagine\VariationPathGenerator' => 'Ibexa\Contracts\Core\Variation\VariationPathGenerator',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp' => 'Symfony\Component\Messenger\Stamp\DeduplicateStamp',
+            'Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp' => 'Symfony\Component\Messenger\Stamp\DeduplicateStamp',
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
+        'Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType' => [
+            'isContainer' => 'isContainer',
+        ],
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
+        'Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft' => [
+            'isContainer' => 'isContainer',
+        ],
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(PropertyToGetterRector::class, [
+        'Ibexa\Core\Repository\Values\ContentType\ContentTypeDraft' => [
+            'isContainer' => 'isContainer',
+        ],
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        ConstToEnumValueRector::class,
+        [
+                'Ibexa\Contracts\Core\Repository\Values\Content\Relation' => [
+                    'enumClass' => 'Ibexa\Contracts\Core\Repository\Values\Content\RelationType',
+                    'constants' => [
+                        'COMMON' => 'COMMON',
+                        'EMBED' => 'EMBED',
+                        'LINK' => 'LINK',
+                        'FIELD' => 'FIELD',
+                        'ASSET' => 'ASSET',
+                    ],
+                ],
+            ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromPhpDocRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Contracts\Rest\Input\Parser',
+                'parse'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        AddReturnTypeFromParentMethodRule::class,
+        [
+            new MethodReturnTypeConfiguration(
+                'Ibexa\Contracts\Rest\Input\Parser',
+                'parse'
+            ),
+        ]
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        ChangeArgumentTypeRector::class,
+        [
+            new ChangeArgumentTypeConfiguration(
+                'Ibexa\\Migration\\Generator\\StepBuilder\\StepFactoryInterface',
+                'create',
+                0,
+                'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject',
+            ),
+            new ChangeArgumentTypeConfiguration(
+                'Ibexa\\Migration\\Generator\\StepBuilder\\AbstractStepFactory',
+                'prepareLogMessage',
+                0,
+                'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject',
+            ),
+            new ChangeArgumentTypeConfiguration(
+                'Ibexa\\Migration\\StepExecutor\\ReferenceDefinition\\ResolverInterface',
+                'resolve',
+                1,
+                'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject'
+            ),
+            new ChangeArgumentTypeConfiguration(
+                'Ibexa\\Migration\\Generator\\StepBuilder\\StepBuilderInterface',
+                'build',
+                0,
+                'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject'
+            ),
+
+            new ChangeArgumentTypeConfiguration(
+                'Ibexa\\Contracts\\Core\\Limitation\\Type',
+                'evaluate',
+                2,
+                'Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject'
+            ),
+        ]
+    );
+
+    $rectorConfig->skip(
+        [
+            // skip removing `createView` method call from `Form` objects, per SF 7 recommendation
+            SimplifyFormRenderingRector::class,
+        ]
+    );
+};

--- a/tests/contracts/IbexaRectorConfigFactoryTest.php
+++ b/tests/contracts/IbexaRectorConfigFactoryTest.php
@@ -40,7 +40,7 @@ final class IbexaRectorConfigFactoryTest extends TestCase
     {
         $expectedSetList = [
             // SYMFONY_53 adds this extra set
-            IbexaSetList::IBEXA_50->value,
+            IbexaSetList::IBEXA_60->value,
             SymfonySetList::SYMFONY_50,
             SymfonySetList::SYMFONY_50_TYPES,
             SymfonySetList::SYMFONY_51,

--- a/tests/lib/Sets/Ibexa60/Fixture/cart_money_factory.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/cart_money_factory.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Cart\Money\MoneyFactory;
+
+readonly class Foo
+{
+    private MoneyFactory $moneyFactory;
+
+    public function __construct(MoneyFactory $moneyFactory)
+    {
+        $this->moneyFactory = $moneyFactory;
+    }
+
+    public function fooBar(MoneyFactory $moneyFactory): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\ProductCatalog\Money\IntlMoneyFactory;
+
+readonly class Foo
+{
+    private IntlMoneyFactory $moneyFactory;
+
+    public function __construct(IntlMoneyFactory $moneyFactory)
+    {
+        $this->moneyFactory = $moneyFactory;
+    }
+
+    public function fooBar(IntlMoneyFactory $moneyFactory): void
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/change_property_to_method_content_type_draft_is_container.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/change_property_to_method_content_type_draft_is_container.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer()];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/change_property_to_method_content_type_is_container.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/change_property_to_method_content_type_is_container.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+
+readonly class Foo
+{
+    public function foo(ContentType $contentType): array
+    {
+        return [$contentType->isContainer];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+
+readonly class Foo
+{
+    public function foo(ContentType $contentType): array
+    {
+        return [$contentType->isContainer()];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/change_property_to_method_contracts_content_type_draft_is_container.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/change_property_to_method_contracts_content_type_draft_is_container.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft;
+
+readonly class Foo
+{
+    public function foo(ContentTypeDraft $contentTypeDraft): array
+    {
+        return [$contentTypeDraft->isContainer()];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/fieldtype_page_const.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/fieldtype_page_const.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;
+
+class Foo {
+    public function foo(): array
+    {
+        return [
+            BlockDefinitionConfigurationCompilerPass::EXTENSION_CONFIG_KEY,
+            \Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\AbstractConfigurationAwareCompilerPass::EXTENSION_CONFIG_KEY
+        ];
+    }
+
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\IbexaFieldTypePageExtension;
+use Ibexa\Bundle\FieldTypePage\DependencyInjection\Compiler\BlockDefinitionConfigurationCompilerPass;
+
+class Foo {
+    public function foo(): array
+    {
+        return [
+            IbexaFieldTypePageExtension::EXTENSION_NAME,
+            IbexaFieldTypePageExtension::EXTENSION_NAME
+        ];
+    }
+
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_class_contracts_deduplicate_stamp.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_class_contracts_deduplicate_stamp.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampUsage
+{
+    public function createStamp(): DeduplicateStamp
+    {
+        return new DeduplicateStamp('key');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampUsage
+{
+    public function createStamp(): DeduplicateStamp
+    {
+        return new DeduplicateStamp('key');
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_class_deduplicate_stamp.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_class_deduplicate_stamp.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampUsage
+{
+    public function createStamp(): DeduplicateStamp
+    {
+        return new DeduplicateStamp('key');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampUsage
+{
+    public function createStamp(): DeduplicateStamp
+    {
+        return new DeduplicateStamp('key');
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_class_update_serializer.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_class_update_serializer.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Gateway\UpdateSerializer;
+
+readonly class Foo
+{
+    public function __construct(UpdateSerializer $updateSerializer)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Gateway\UpdateSerializer\XmlUpdateSerializer;
+
+readonly class Foo
+{
+    public function __construct(XmlUpdateSerializer $updateSerializer)
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_const_content_type_identifier.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_const_content_type_identifier.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Migration\ValueObject\ContentType\Matcher;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return Matcher::CONTENT_TYPE_IDENTIFIER;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Migration\StepExecutor\ContentType\IdentifierFinder;
+use Ibexa\Migration\ValueObject\ContentType\Matcher;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return IdentifierFinder::CONTENT_TYPE_IDENTIFIER;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_const_tree_root.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_const_tree_root.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Bundle\FormBuilder\DependencyInjection\Configuration;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return Configuration::TREE_ROOT;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Bundle\FormBuilder\DependencyInjection\IbexaFormBuilderExtension;
+use Ibexa\Bundle\FormBuilder\DependencyInjection\Configuration;
+
+readonly class Foo
+{
+    public function fooBar(): string
+    {
+        return IbexaFormBuilderExtension::EXTENSION_NAME;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_field_namespace_content_to_common.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_field_namespace_content_to_common.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Query\Content\CriterionVisitor\Field;
+
+readonly class Foo
+{
+    public function __construct(Field $field)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Solr\Query\Common\CriterionVisitor\Field;
+
+readonly class Foo
+{
+    public function __construct(Field $field)
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_property_searchresult_count.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_property_searchresult_count.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Trash\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): string
+    {
+        return $searchResult->count;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Trash\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): string
+    {
+        return $searchResult->totalCount;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_property_searchresult_spell_suggestion.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_property_searchresult_spell_suggestion.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): array
+    {
+        return [$searchResult->spellSuggestion];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ReplaceCartMoneyFactoryRector\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
+
+readonly class Foo
+{
+    public function foo(SearchResult $searchResult): array
+    {
+        return [$searchResult->spellcheck];
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_relation_const_class.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_relation_const_class.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Relation;
+
+readonly class Foo
+{
+    public function bar(Relation $relation)
+    {
+        $type = Relation::FIELD;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\RelationType;
+use Ibexa\Contracts\Core\Repository\Values\Content\Relation;
+
+readonly class Foo
+{
+    public function bar(Relation $relation)
+    {
+        $type = RelationType::FIELD->value;
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rename_variation_interface.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rename_variation_interface.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
+
+class SomeFormatVariationGenerator implements VariationPathGenerator
+{
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
+
+class SomeFormatVariationGenerator implements VariationPathGenerator
+{
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rest_parser.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rest_parser.php.inc
@@ -1,0 +1,79 @@
+<?php
+
+namespace Ibexa\Contracts\Rest\Input;
+
+abstract class BaseParser extends Parser
+{
+}
+
+abstract class Parser
+{
+    abstract public function parse(array $data, ParsingDispatcher $parsingDispatcher): mixed;
+}
+
+?>
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Rest\Input\BaseParser;
+use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
+
+class SomeParserWithDoc extends BaseParser
+{
+    /**
+     * @return \stdClass
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+    }
+}
+
+class SomeParserWithoutDoc extends BaseParser
+{
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Contracts\Rest\Input;
+
+abstract class BaseParser extends Parser
+{
+}
+
+abstract class Parser
+{
+    abstract public function parse(array $data, ParsingDispatcher $parsingDispatcher): mixed;
+}
+
+?>
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Rest\Input\BaseParser;
+use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
+
+class SomeParserWithDoc extends BaseParser
+{
+    /**
+     * @return \stdClass
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): \stdClass
+    {
+    }
+}
+
+class SomeParserWithoutDoc extends BaseParser
+{
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): mixed
+    {
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/rest_rename.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/rest_rename.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Rest\Output\Generator;
+use Ibexa\Rest\Output\FieldTypeSerializer;
+
+class Foo {
+    public function mediaTypeGenerator(): void
+    {
+        $generator = new Generator();
+
+        return $generator->generateMediaType('name', 'type');
+    }
+
+    public function fieldTypeSerializer(): void
+    {
+        $serializer = new FieldTypeSerializer();
+
+        $generator = new Generator();
+        $contentType = new ContentType();
+        $field = new Field();
+
+        return $serializer->serializeFieldValue($generator, $contentType, $field);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Rest\Output\Generator;
+use Ibexa\Rest\Output\FieldTypeSerializer;
+
+class Foo {
+    public function mediaTypeGenerator(): void
+    {
+        $generator = new Generator();
+
+        return $generator->generateMediaTypeWithVendor('name', 'type');
+    }
+
+    public function fieldTypeSerializer(): void
+    {
+        $serializer = new FieldTypeSerializer();
+
+        $generator = new Generator();
+        $contentType = new ContentType();
+        $field = new Field();
+
+        return $serializer->serializeContentFieldValue($generator, $field);
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/simplified_request_properties.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/simplified_request_properties.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
+
+$request = new SimplifiedRequest();
+$pathInfo = $request->pathinfo;
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
+
+$request = new SimplifiedRequest();
+$pathInfo = $request->getPathInfo();
+
+?>

--- a/tests/lib/Sets/Ibexa60/Fixture/some_class.php.inc
+++ b/tests/lib/Sets/Ibexa60/Fixture/some_class.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+
+class FooBar {
+    public function foo(): RepositoryConfigurationProvider
+    {
+        return $this->bar(RepositoryConfigurationProvider::class);
+    }
+
+    public function bar(string $class): RepositoryConfigurationProvider
+    {
+        return new $class();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60\Fixture;
+
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
+
+class FooBar {
+    public function foo(): RepositoryConfigurationProviderInterface
+    {
+        return $this->bar(RepositoryConfigurationProviderInterface::class);
+    }
+
+    public function bar(string $class): RepositoryConfigurationProviderInterface
+    {
+        return new $class();
+    }
+}
+
+?>

--- a/tests/lib/Sets/Ibexa60/Ibexa60Test.php
+++ b/tests/lib/Sets/Ibexa60/Ibexa60Test.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rector\Tests\Sets\Ibexa60;
+
+use Ibexa\Rector\Tests\Sets\AbstractIbexaRectorSetTestCase;
+
+final class Ibexa60Test extends AbstractIbexaRectorSetTestCase
+{
+    protected static function getCurrentDirectory(): string
+    {
+        return __DIR__;
+    }
+}

--- a/tests/lib/Sets/Ibexa60/config/configured_rule.php
+++ b/tests/lib/Sets/Ibexa60/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([IbexaSetList::IBEXA_60->value]);
+    $rectorConfig->importNames();
+};


### PR DESCRIPTION
| :ticket: Issue | [IBX-12084](https://ibexa.atlassian.net/browse/IBX-12084) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Added a new `IbexaSetList::IBEXA_60` rule set (`src/contracts/Sets/ibexa-60.php`) for upgrading projects to Ibexa DXP 6.0.

Following the existing pattern between the 4.6 and 5.0 sets, the new set is a standalone copy of the 5.0 set (sets are self-contained and not composed from each other), with a single difference: the `DeduplicateStamp` rename rule now migrates both `Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp` and `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp` to the native `Symfony\Component\Messenger\Stamp\DeduplicateStamp` (available since Symfony 7.3), instead of renaming the Bundle class to the Contracts one. The 4.6 and 5.0 sets remain untouched.

#### For QA:
Covered by automated tests: `tests/lib/Sets/Ibexa60` mirrors the existing `Ibexa50` set test suite and additionally verifies that both legacy `DeduplicateStamp` classes (Bundle and Contracts namespaces) are renamed to the Symfony Messenger one.

Manual check (optional): in a project with this package, run Rector with `IbexaSetList::IBEXA_60->value` against code using either legacy `DeduplicateStamp` class and confirm it is rewritten to `Symfony\Component\Messenger\Stamp\DeduplicateStamp`.

#### Documentation:
A new `IbexaSetList::IBEXA_60` Rector set is available for upgrading projects to Ibexa DXP 6.0. When it is applied, usages of `Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp` and `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp` are migrated to `Symfony\Component\Messenger\Stamp\DeduplicateStamp`.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
-->


[IBX-12084]: https://ibexa.atlassian.net/browse/IBX-12084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ