### PR TITLE
Narrowed rector/rector dependency below 2.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.0, <2.6.2",
         "symfony/console": "^7.4",
         "symfony/finder": "^7.4",
         "symfony/filesystem": "^7.4"


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
`rector/rector` 2.6.2 (released 2026-08-12) ships a `rector/rector-symfony` build that removed the deprecated version-based set constants `SymfonySetList::SYMFONY_50`…`SYMFONY_74` (rectorphp/rector-symfony#1019). `IbexaRectorConfigFactory` and the `rector.php` configs of downstream Ibexa packages still reference those constants, so any fresh `composer install` now fails with:

```
[ERROR] Undefined constant Rector\Symfony\Set\SymfonySetList::SYMFONY_60
```

This PR narrows the `rector/rector` requirement to `^2.0, <2.6.2` so that composer resolves 2.6.1 — the last working release — keeping this package and the CI jobs of all packages depending on it green.

Migrating `IbexaRectorConfigFactory` and per-package rector configs to the composer-based sets (`->withComposerBased(symfony: true)`) is a follow-up topic; this change only unblocks CI.

#### For QA:
Nothing to test manually — this is a dev-dependency version cap. Verified by `composer update rector/rector` resolving `2.6.2 => 2.6.1` and the unit test suite passing (68 tests, 79 assertions), including `IbexaRectorConfigFactoryTest` which exercises the removed constants.

#### Documentation:
No client-facing impact to document.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
-->
